### PR TITLE
Audit logs now print user info as well

### DIFF
--- a/packages/apollo-voyager-audit/src/auditLog.ts
+++ b/packages/apollo-voyager-audit/src/auditLog.ts
@@ -14,16 +14,18 @@ interface AuditLogger {
     parent: any
     arguments: any
     clientInfo: any
+    authenticated: boolean
+    userInfo: any
   }): void
 }
 
 const log = pino()
 const auditLogger: AuditLogger = log.child({tag: 'AUDIT'})
 
-export function auditLog (success: boolean, request: any, info: GraphQLResolveInfo, parent: any, args: any, msg: string) {
+export function auditLog (success: boolean, context: any, info: GraphQLResolveInfo, parent: any, args: any, msg: string) {
   auditLogger.info({
     msg: msg || '',
-    requestId: request ? request.id : '',
+    requestId: context && context.request ? context.request.id : '',
     operationType: info.operation.operation,
     fieldName: info.fieldName,
     parentTypeName: info.parentType.name,
@@ -31,6 +33,8 @@ export function auditLog (success: boolean, request: any, info: GraphQLResolveIn
     success,
     parent,
     arguments: args,
-    clientInfo: request && request.body && request.body.extensions && request.body.extensions.metrics || undefined
+    clientInfo: context && context.request && context.request.body && context.request.body.extensions && context.request.body.extensions.metrics || undefined,
+    authenticated: !!(context && context.auth && context.auth.isAuthenticated()),
+    userInfo: (context && context.auth && context.auth.accessToken) ? context.auth.accessToken.content : undefined
   })
 }

--- a/packages/apollo-voyager-server/src/voyagerResolver.ts
+++ b/packages/apollo-voyager-server/src/voyagerResolver.ts
@@ -20,7 +20,7 @@ function voyagerResolverPartial (config: VoyagerResolversConfig): ResolverWrappe
         try {
           const result = await resolverFn(obj, args, context, info)
           if (config && config.auditLogging) {
-            auditLog(true, context.request, info, obj, args, '')
+            auditLog(true, context, info, obj, args, '')
           }
           resolve(result)
 
@@ -34,7 +34,7 @@ function voyagerResolverPartial (config: VoyagerResolversConfig): ResolverWrappe
           // NOPE: updateResolverMetrics(info, timeTook)
           // but, we audit log in case of failure too
           if (config && config.auditLogging) {
-            auditLog(false, context.request, info, obj, args, error.message)
+            auditLog(false, context, info, obj, args, error.message)
           }
           reject(error)
         }


### PR DESCRIPTION
https://issues.jboss.org/browse/AEROGEAR-8320

Verification:

* Do as defined in doc/guides/examples.md to set up Keycloak
* Run this example (didn't want to modify Keycloak example)
```
const fs = require('fs')
const path = require('path')
const express = require('express')
const { makeExecutableSchema } = require('graphql-tools')

const { ApolloVoyagerServer, voyagerResolvers, gql } = require('../../packages/apollo-voyager-server')
const { KeycloakSecurityService } = require('../../packages/apollo-voyager-keycloak')


const keycloakConfig = JSON.parse(fs.readFileSync(path.resolve(__dirname, './config/keycloak.json')))

// This is our Schema Definition Language (SDL)
const typeDefs = gql`

  # In the older version of graphql in the data sync server
  # We did not have to define the directive here.
  # For some reason we do now, otherwise makeExecutableSchema does not work.

  directive @hasRole(role: [String]) on FIELD | FIELD_DEFINITION

  type Query {
    hello: String @hasRole(role: "admin")
  }
`

// Resolver functions. This is our business logic
let resolvers = {
  Query: {
    hello: (obj, args, context, info) => {

      // log some of the auth related info added to the context
      console.log(context.auth.isAuthenticated())
      console.log(context.auth.accessToken.content.name)

      const name = context.auth.accessToken.content.name || 'world'
      return `Hello ${name} from ${context.serverName}`
    }
  }
}


resolvers = voyagerResolvers(resolvers, { auditLogging: true })

// Initialize the keycloak service
const keycloakService = new KeycloakSecurityService(keycloakConfig)

// get the keycloak context provider and directives
const schemaDirectives = keycloakService.getSchemaDirectives()

const schema = makeExecutableSchema({
  typeDefs,
  resolvers,
  // add the keycloak directives
  schemaDirectives
})

// The context is a function or object that can add some extra data
// That will be available via the `context` argument the resolver functions
const context = ({ req }) => {
  return {
    serverName: 'Voyager Server'
  }
}

// Initialize the apollo voyager server with our schema and context

const apolloConfig = {
  schema,
  context
}

const voyagerConfig = {
  securityService: keycloakService
}

const server = ApolloVoyagerServer(apolloConfig, voyagerConfig)

const app = express()

// Apply the keycloak middleware to the express app.
// It's very important this is done before
// Applying the apollo middleware
// This function can also take an `options` argument
// To specify things like apiPath and other potential config
keycloakService.applyAuthMiddleware(app)
server.applyMiddleware({ app })

const port = 4000
app.listen({ port }, () =>
  console.log(`🚀 Server ready at http://localhost:${port}${server.graphqlPath}`)
)
```

* See this in stdout
```
{
  "level": 30,
  "time": 1545725765994,
  "pid": 2988,
  "hostname": "localhost.localdomain",
  "tag": "AUDIT",
  "msg": "",
  "operationType": "query",
  "fieldName": "hello",
  "parentTypeName": "Query",
  "path": "hello",
  "success": true,
  "arguments": {},
  "authenticated": true,
  "userInfo": {
    "jti": "6ae0966a-9d61-430b-8167-d2b3c0b42709",
    "exp": 1545761725,
    "nbf": 0,
    "iat": 1545725725,
    "iss": "http://localhost:8080/auth/realms/voyager-testing",
    "aud": "voyager-testing",
    "sub": "ea2312e9-1aae-4b67-8674-a3aacf20a71d",
    "typ": "Bearer",
    "azp": "voyager-testing",
    "auth_time": 1545725725,
    "session_state": "1ba4d429-8010-4f38-8002-9cc72550850d",
    "acr": "1",
    "allowed-origins": [
      "*"
    ],
    "realm_access": {
      "roles": [
        "admin",
        "uma_authorization"
      ]
    },
    "resource_access": {
      "voyager-testing": {
        "roles": [
          "admin"
        ]
      },
      "account": {
        "roles": [
          "manage-account",
          "manage-account-links",
          "view-profile"
        ]
      }
    },
    "name": "Ali Ok",
    "preferred_username": "developer",
    "given_name": "Ali",
    "family_name": "Ok",
    "email": "aliok@asdasdasd.com"
  },
  "v": 1
}
```