### PR TITLE
feat: CircleCI pushes basic example server container on release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,10 @@ jobs:
       - setup_remote_docker:
           version: 17.05.0-ce
           docker_layer_caching: true
-      - run: cd examples && TAG=$CIRCLE_TAG ./push-script.sh basic
+      - run: |
+          cd examples
+          docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
+          TAG=$CIRCLE_TAG ./push-script.sh basic
 workflows:
   version: 2
   build_and_release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,13 +65,16 @@ jobs:
       - run: TAG=$CIRCLE_TAG npm run release:validate
       - run: TAG=$CIRCLE_TAG npm run publish
   containers_publish:
-    working_directory: ~/examples
+    working_directory: ~/aerogear
     docker:
       # Node 8 LTS
-      - image: circleci/node:carbon
+      - image: docker:17.05.0-ce-git
     steps:
       - checkout
-      - run: TAG=$CIRCLE_TAG ./push-script.sh basic
+      - setup_remote_docker:
+          version: 17.05.0-ce
+          docker_layer_caching: true
+      - run: cd examples && TAG=$CIRCLE_TAG ./push-script.sh basic
 workflows:
   version: 2
   build_and_release:
@@ -95,7 +98,10 @@ workflows:
               ignore: /.*/
       - containers_publish:
           requires:
-            - npm_publish
+            - test_examples
           filters:
             tags:
               only: /.*/
+            branches:
+              only:
+                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
       - run: CI=true npm run release:prep
       - run: TAG=$CIRCLE_TAG npm run release:validate
       - run: TAG=$CIRCLE_TAG npm run publish
-  containers_publish:
+  publish_example_containers:
     working_directory: ~/aerogear
     docker:
       # image for building docker containers
@@ -100,8 +100,9 @@ workflows:
               only: /.*/ # allow anything because tag syntax is validated as part of validate-release.sh
             branches:
               ignore: /.*/
-      - containers_publish:
+      - publish_example_containers:
           requires:
+            - npm_publish
             - test_examples
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,10 +67,11 @@ jobs:
   containers_publish:
     working_directory: ~/aerogear
     docker:
-      # Node 8 LTS
+      # image for building docker containers
       - image: docker:17.05.0-ce-git
     steps:
       - checkout
+      # special woraround to allow running docker in docker https://circleci.com/docs/2.0/building-docker-images/
       - setup_remote_docker:
           version: 17.05.0-ce
           docker_layer_caching: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,7 @@ jobs:
       - run: CI=true npm run release:prep
       - run: TAG=$CIRCLE_TAG npm run release:validate
       - run: TAG=$CIRCLE_TAG npm run publish
+      - run: cd examples && TAG=$CIRCLE_TAG ./push-script.sh basic
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,8 +64,14 @@ jobs:
       - run: CI=true npm run release:prep
       - run: TAG=$CIRCLE_TAG npm run release:validate
       - run: TAG=$CIRCLE_TAG npm run publish
-      - run: cd examples && TAG=$CIRCLE_TAG ./push-script.sh basic
-
+  containers_publish:
+    working_directory: ~/examples
+    docker:
+      # Node 8 LTS
+      - image: circleci/node:carbon
+    steps:
+      - checkout
+      - run: TAG=$CIRCLE_TAG ./push-script.sh basic
 workflows:
   version: 2
   build_and_release:
@@ -87,3 +93,9 @@ workflows:
               only: /.*/ # allow anything because tag syntax is validated as part of validate-release.sh
             branches:
               ignore: /.*/
+      - containers_publish:
+          requires:
+            - npm_publish
+          filters:
+            tags:
+              only: /.*/


### PR DESCRIPTION
https://issues.jboss.org/browse/AEROGEAR-8436

### Description

Publishes `aerogear/voyager-server-example-basic` after each release (tag) and on master builds.

Tested in my fork.