### PR TITLE
AEROGEAR-8514 - Collect client info in sync server side and expose th…

### DIFF
--- a/packages/voyager-metrics/src/api/DefaultMetrics.ts
+++ b/packages/voyager-metrics/src/api/DefaultMetrics.ts
@@ -1,7 +1,7 @@
 import { Metrics } from './Metrics'
 
 export class DefaultMetrics implements Metrics {
-  public updateResolverMetrics (resolverInfo: any, responseTime: number): void {
+  public updateResolverMetrics (success: boolean, context: any, resolverInfo: any, responseTime: number): void {
     // no op
   }
   public recordConflictMetrics(resolverInfo: any): void {

--- a/packages/voyager-metrics/src/api/Metrics.ts
+++ b/packages/voyager-metrics/src/api/Metrics.ts
@@ -1,4 +1,4 @@
 export interface Metrics {
-  updateResolverMetrics (resolverInfo: any, responseTime: number): void
+  updateResolverMetrics (success: boolean, context: any, resolverInfo: any, responseTime: number): void
   recordConflictMetrics(resolverInfo: any): void
 }

--- a/packages/voyager-server/src/voyagerResolver.ts
+++ b/packages/voyager-server/src/voyagerResolver.ts
@@ -29,13 +29,11 @@ function voyagerResolverPartial (config: CompleteVoyagerConfig): ResolverWrapper
           }
 
           const timeTook = Date.now() - resolverStartTime
-          metrics.updateResolverMetrics(info, timeTook)
+          metrics.updateResolverMetrics(true, context, info, timeTook)
           auditLogger.logResolverCompletion('', true, obj, args, context, info)
         } catch (error) {
-          // we only publish time in success. const timeTook
-          // NOPE: const timeTook = Date.now() - resolverStartTime
-          // NOPE: updateResolverMetrics(info, timeTook)
-          // but, we audit log in case of failure too
+          const timeTook = Date.now() - resolverStartTime
+          metrics.updateResolverMetrics(false, context, info, timeTook)
           if (auditLogger) {
             auditLogger.logResolverCompletion(error.message, false, obj, args, context, info)
           }


### PR DESCRIPTION
…em in the metrics endpoint

Modifications:
1. Collect unique client and user count and give that info to Prometheus
2. Add success and authenticated labels to 2 metrics where it makes sense, so that we can create a success/failure and authenticated/anonymous graphs in Grafana
3. We didn't record the failed resolvers for Prometheus. Now with the introduction of success/failure above, we do it.

@psturc testing this whole thing is a pain in the ass. I have an [example application](https://github.com/aliok/nodejs-ex) which uses Voyager framework with metrics+auditLogs+keycloak and I have a [tool](https://github.com/aliok/aerogear-sync-metrics-generator/) that executes lots of GraphQL requests against that server.
But you need to do `npm link`, Keycloak configs and things like that. 

If we don't want to go that way here's a smoke test:

* Run metrics example and go to http://localhost:4000/graphql
* Execute `{hello}` bunch of times
* See these metrics (they're new)
```
unique_clients 1
unique_users 1
```
* See these metrics (they have new labels)
```
requests_resolved{operation_type="query",path="Query.hello",success="true",authenticated="false"} 4
requests_resolved_total{operation_type="query",path="Query.hello",success="true",authenticated="false"} 4
```

BTW, I copied the metrics result of the setup I mentioned earlier here: https://gist.github.com/aliok/ccea8e59f23c18ba1fc5966625fbab32



