### PR TITLE
feat: add a getTypeDefs method to the SecurityService interface

### DIFF
--- a/examples/keycloak/server.js
+++ b/examples/keycloak/server.js
@@ -15,8 +15,6 @@ const typeDefs = gql`
   # We did not have to define the directive here.
   # For some reason we do now, otherwise makeExecutableSchema does not work.
 
-  directive @hasRole(role: [String]) on FIELD | FIELD_DEFINITION
-
   type Query {
     hello: String @hasRole(role: "admin")
   }
@@ -50,7 +48,7 @@ const context = ({ req }) => {
 // Initialize the voyager server with our schema and context
 
 const apolloConfig = {
-  typeDefs,
+  typeDefs: [typeDefs, keycloakService.getTypeDefs()],
   resolvers,
   context
 }

--- a/packages/voyager-keycloak/src/KeycloakSecurityService.ts
+++ b/packages/voyager-keycloak/src/KeycloakSecurityService.ts
@@ -28,6 +28,10 @@ export class KeycloakSecurityService implements SecurityService {
     this.log = options && options.log ? options.log : console
   }
 
+  public getTypeDefs(): string {
+    return 'directive @hasRole(role: [String]) on FIELD | FIELD_DEFINITION'
+  }
+
   public getSchemaDirectives (): SchemaDirectives {
     return this.schemaDirectives
   }

--- a/packages/voyager-keycloak/src/api/DefaultSecurityService.ts
+++ b/packages/voyager-keycloak/src/api/DefaultSecurityService.ts
@@ -3,6 +3,9 @@ import { SecurityService } from './SecurityService'
 
 export class DefaultSecurityService implements SecurityService {
 
+  public getTypeDefs () {
+    return ''
+  }
   public getSchemaDirectives () {
     return {}
   }

--- a/packages/voyager-keycloak/src/api/SecurityService.ts
+++ b/packages/voyager-keycloak/src/api/SecurityService.ts
@@ -10,6 +10,13 @@ import { AuthContextProviderClass } from './AuthContextProvider'
  * with something like Keycloak, Auth0, Google Services etc.
  */
 export interface SecurityService {
+
+  /**
+   * getTypeDefs returns any additional SDL that should be added to a GraphQL schema
+   * to work with the security service.
+   */
+  getTypeDefs (): string
+
   /**
    * getSchemaDirectives should return an object containing directive
    * implementations. e.g. @isAuthenticated, @hasRole

--- a/packages/voyager-server/src/config/DefaultVoyagerConfig.test.ts
+++ b/packages/voyager-server/src/config/DefaultVoyagerConfig.test.ts
@@ -27,6 +27,9 @@ test('DefaultVoyagerConfig.merge() will override default security service with u
     }
   }
   class DummySecurityService implements SecurityService {
+    public getTypeDefs () {
+      return ''
+    }
     public getAuthContextProvider () {
       return CustomAuthContextProvider
     }

--- a/packages/voyager-server/src/context/ApolloVoyagerContextProvider.test.ts
+++ b/packages/voyager-server/src/context/ApolloVoyagerContextProvider.test.ts
@@ -37,6 +37,9 @@ test('Passing a custom security service will result in that service being inside
   }
 
   class CustomSecurityService implements SecurityService {
+    public getTypeDefs () {
+      return ''
+    }
     public getSchemaDirectives() {
       return {}
     }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/aerogear/voyager-server/blob/master/CONTRIBUTING.md
-->

### Description

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

I understand that we're supposed to be in a code freeze now but I had this idea after reading through docs for the [accouts-js](https://github.com/accounts-js/accounts) project. I realised this area around defining the `hasRole` directive in the SDL is something the user should not have to do. If you think about it, this is actually an implementation detail of the keycloak security service. I've modified the security service interface to have a `getTypeDefs` function that provides any necessary SDL to make the security service work. Take a look at the keycloak example to see how this works.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](../doc/guides/pull-requests.md#commit-message-guidelines)