### PR TITLE
fix: ensure correct versions of graphql are listed as peer dependencies

### DIFF
--- a/packages/voyager-audit/package.json
+++ b/packages/voyager-audit/package.json
@@ -31,6 +31,9 @@
     "ts-node": "7.0.1",
     "typescript": "3.3.3333"
   },
+  "peerDependencies": {
+    "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0"
+  },
   "ava": {
     "compileEnhancements": false,
     "extensions": [

--- a/packages/voyager-conflicts/package.json
+++ b/packages/voyager-conflicts/package.json
@@ -28,6 +28,9 @@
     "ts-node": "7.0.1",
     "typescript": "3.3.3333"
   },
+  "peerDependencies": {
+    "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/voyager-keycloak/package.json
+++ b/packages/voyager-keycloak/package.json
@@ -39,6 +39,9 @@
     "ts-node": "7.0.1",
     "typescript": "3.3.3333"
   },
+  "peerDependencies": {
+    "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0"
+  },
   "ava": {
     "compileEnhancements": false,
     "extensions": [

--- a/packages/voyager-server/package.json
+++ b/packages/voyager-server/package.json
@@ -54,6 +54,6 @@
     ]
   },
   "peerDependencies": {
-    "graphql": "0.13.2"
+    "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0"
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/aerogear/voyager-server/blob/master/CONTRIBUTING.md
-->

### Description

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

Prepare for Apollo Server version updates by ensuring we list the same peer dependencies as them. https://github.com/apollographql/apollo-server/blob/master/packages/apollo-server/package.json#L30-L32

Additionally, it turns out that the keycloak, conflicts and audit package were using things from the `graphql` module without specifying it as a dependency in their `package.json` files.

This PR prepares us for merging https://github.com/aerogear/voyager-server/pull/119

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](../doc/guides/pull-requests.md#commit-message-guidelines)