### PR TITLE
Add reject method to conflict resolution

### DIFF
--- a/packages/voyager-conflicts/src/api/ObjectState.ts
+++ b/packages/voyager-conflicts/src/api/ObjectState.ts
@@ -41,6 +41,15 @@ export interface ObjectState {
    * @param serverState the current state of the object on the server
    * @param clientState the state of the object the client wishes to perform some mutation with
    */
-  resolveOnServer (strategy: ConflictResolutionStrategy, serverState: ObjectStateData, clientState: ObjectStateData): Promise<ConflictResolution>
+  resolveOnServer(strategy: ConflictResolutionStrategy, serverState: ObjectStateData, clientState: ObjectStateData): Promise<ConflictResolution>
 
+  /**
+   * Inform clients that changes were rejected due to conflict without applying them to server.
+   * This means that client need to apply their changes again on top of the recent server and
+   * no automatic conflict resolution is possible.
+   *
+   * @param serverState
+   * @param clientState
+   */
+  reject(serverState: ObjectStateData, clientState: ObjectStateData): ConflictResolution
 }

--- a/packages/voyager-conflicts/src/states/HashObjectState.ts
+++ b/packages/voyager-conflicts/src/states/HashObjectState.ts
@@ -29,6 +29,10 @@ export class HashObjectState implements ObjectState {
     return new ConflictResolution(false, serverState, clientState)
   }
 
+  public reject(serverState: ObjectStateData, clientState: ObjectStateData) {
+    return new ConflictResolution(true, serverState, clientState)
+  }
+
   public async resolveOnServer(strategy: ConflictResolutionStrategy, serverState: ObjectStateData, clientState: ObjectStateData) {
     let resolvedState = strategy(serverState, clientState)
 

--- a/packages/voyager-conflicts/src/states/VersionedObjectState.ts
+++ b/packages/voyager-conflicts/src/states/VersionedObjectState.ts
@@ -29,7 +29,11 @@ export class VersionedObjectState implements ObjectState {
   }
 
   public nextState(currentObjectState: ObjectStateData) {
-    currentObjectState.version = currentObjectState.version + 1
+    if (currentObjectState.version) {
+      currentObjectState.version = currentObjectState.version + 1
+    } else {
+      currentObjectState.version = 1
+    }
     return currentObjectState
   }
 

--- a/packages/voyager-conflicts/src/states/VersionedObjectState.ts
+++ b/packages/voyager-conflicts/src/states/VersionedObjectState.ts
@@ -37,6 +37,10 @@ export class VersionedObjectState implements ObjectState {
     return new ConflictResolution(false, serverState, clientState)
   }
 
+  public reject(serverState: ObjectStateData, clientState: ObjectStateData) {
+    return new ConflictResolution(true, serverState, clientState)
+  }
+
   public async resolveOnServer(strategy: ConflictResolutionStrategy, serverState: ObjectStateData, clientState: ObjectStateData) {
     let resolvedState = strategy(serverState, clientState)
 

--- a/packages/voyager-conflicts/src/strategies/index.ts
+++ b/packages/voyager-conflicts/src/strategies/index.ts
@@ -1,18 +1,12 @@
 import { ConflictResolutionStrategy } from '../api/ConflictResolutionStrategy'
 import { ObjectStateData } from '../api/ObjectStateData'
 
-function clientWinsstrategy (serverState: ObjectStateData, clientState: ObjectStateData) {
+function clientWinsStrategy (serverState: ObjectStateData, clientState: ObjectStateData) {
   return clientState
 }
 
-function serverWinsStrategy (serverState: ObjectStateData, clientState: ObjectStateData) {
-  return serverState
-}
-
-const clientWins: ConflictResolutionStrategy = clientWinsstrategy
-const serverWins: ConflictResolutionStrategy = serverWinsStrategy
+const clientWins: ConflictResolutionStrategy = clientWinsStrategy
 
 export const strategies = {
-  clientWins,
-  serverWins
+  clientWins
 }

--- a/packages/voyager-conflicts/test/VersionedObjectState.test.ts
+++ b/packages/voyager-conflicts/test/VersionedObjectState.test.ts
@@ -84,18 +84,17 @@ test('resolveOnServer works with the client wins strategy', async (t) => {
   t.deepEqual(resolution.response, expected.response)
 })
 
-test('resolveOnServer works with the server wins strategy', async (t) => {
+test('resolveOnServer works with the server (reject) strategy', async (t) => {
   const serverState = { name: 'AeroGear', version: 2 }
   const clientState = { name: 'Client', version: 1 }
   const objectState = new VersionedObjectState()
 
-  const strategy = strategies.serverWins
 
-  const resolution = await objectState.resolveOnServer(strategy, serverState, clientState)
+  const resolution = await objectState.reject(serverState, clientState)
 
   const expectedResolvedState = {
     name: 'AeroGear' ,
-    version: 3
+    version: 2
   }
 
   const expected = {


### PR DESCRIPTION
## Motivation

Users should be able to reject client changes without writing data to the server.
With strategy serverWins we writing the same data back to the database. 
This is not needed and it can actually override the writes that happened in the time between reading and write. This method is just a helper to document this case and allow to reject changes made by the client explicitly. 

This approach will work with the client out of the box as for server-side resolution users will receive notification and can act on it.
More info in AEROGEAR-8614 

## Verification

Unit tests providing verification for this case. 
I have also tested my manually changing strategy in examples.
Reject method is a corner case so it is best to not include that in conflict example and just document this. 

@darahayes @jhellar Minor updates in docs will be needed after that change:
- Remove any occurrences of serverWins strategy
- Describe the reject method and purpose of this method