### PR TITLE
fix: ensure onSubscriptionConnect throws when no connectionParams supplied

### DIFF
--- a/packages/voyager-keycloak/src/KeycloakSecurityService.ts
+++ b/packages/voyager-keycloak/src/KeycloakSecurityService.ts
@@ -97,6 +97,9 @@ export class KeycloakSecurityService implements SecurityService {
   }
 
   public async onSubscriptionConnect(connectionParams: any, webSocket: any, context: any): Promise<any> {
+    if (!connectionParams || typeof connectionParams !== 'object') {
+      throw new Error('Access Denied - missing connection parameters for Authentication')
+    }
     const header = connectionParams.Authorization
                   || connectionParams.authorization
                   || connectionParams.Auth

--- a/packages/voyager-keycloak/test/KeycloakSecurityService.test.ts
+++ b/packages/voyager-keycloak/test/KeycloakSecurityService.test.ts
@@ -3,6 +3,43 @@ import test from 'ava'
 import { KeycloakSecurityService } from '../src/KeycloakSecurityService'
 import { Token } from '../src/KeycloakToken';
 
+test('onSubscriptionConnect throws if no connectionParams Provided', async t => {
+  const stubKeycloak = {
+    grantManager: {
+      validateToken: (token: string, type: 'string') => {
+        return new Promise((resolve, reject) => {
+          resolve(true)
+        })
+      }
+    }
+  }
+
+  const securityService = new KeycloakSecurityService({}, { log: console, keycloak: stubKeycloak })
+
+  await t.throwsAsync(async () => {
+    await securityService.onSubscriptionConnect(null, {}, {})
+  }, 'Access Denied - missing connection parameters for Authentication')
+})
+
+test('onSubscriptionConnect throws if no connectionParams is not an object', async t => {
+  const stubKeycloak = {
+    grantManager: {
+      validateToken: (token: string, type: 'string') => {
+        return new Promise((resolve, reject) => {
+          resolve(true)
+        })
+      }
+    }
+  }
+
+  const securityService = new KeycloakSecurityService({}, { log: console, keycloak: stubKeycloak })
+  const connectionParams = 'not an object'
+
+  await t.throwsAsync(async () => {
+    await securityService.onSubscriptionConnect(connectionParams, {}, {})
+  }, 'Access Denied - missing connection parameters for Authentication')
+})
+
 test('onSubscriptionConnect throws if no Auth provided', async t => {
   const stubKeycloak = {
     grantManager: {


### PR DESCRIPTION
I found a case where if keycloak auth is enabled on the server side but the client sends absolutely nothing in its connection params, an error is thrown like `cannot read property Authorization of undefined.` This is because the `onSubscriptionConnect` function trying to access some properties on the `connectionParams` when it is undefined.

The desired outcome of the client not being able to connect is achieved but the error message is wrong.

This PR checks for that case and also adds some extra tests for it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/aerogear/voyager-server/blob/master/CONTRIBUTING.md
-->

### Description

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](../doc/guides/pull-requests.md#commit-message-guidelines)